### PR TITLE
Use 'switch-client' to prevent nested sessions.

### DIFF
--- a/tmux-up
+++ b/tmux-up
@@ -63,4 +63,4 @@ then
   tmux select-window -t 1
 fi
 
-tmux attach -t "$SESSION"
+tmux switch-client -t "$SESSION"

--- a/tmux-up
+++ b/tmux-up
@@ -58,7 +58,7 @@ fi
 
 if ! tmux has-session -t "$SESSION" > /dev/null 2>&1
 then
-  tmux new-session -d -s "$SESSION"
+  TMUX='' tmux new-session -d -s "$SESSION"
   xargs -L1 tmux < "$CONF"
   tmux select-window -t 1
 fi

--- a/tmux-up
+++ b/tmux-up
@@ -63,4 +63,9 @@ then
   tmux select-window -t 1
 fi
 
-tmux switch-client -t "$SESSION"
+if [ -z "$TMUX" ]
+then
+  tmux attach -t "$SESSION"
+else
+  tmux switch-client -t "$SESSION"
+fi


### PR DESCRIPTION
Using switch-client ensures, that we do not start a new session in a possibly running current session, instead the current session is replaced by the new one. This way we can use tmux-up to quickly switch between projects/configurations.
