### PR TITLE
Load default configurations. This closes #5

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -59,6 +59,18 @@ Under the hood `tmux-up` will:
 
 If you detach from the `example/dev` session, simply re-run `tmux-up dev.conf` which will reattach you to the session.
 
+## Default Configurations
+
+You can place default configurations in `~/.tmux/`, for example `~/.tmux/default.conf`. To attach a default configuration just run
+
+```
+ ❯ tmux-up default.conf
+```
+
+in any directory. This will create a `tmux` session named `default` and invoke each line in `~/.tmux/default.conf`.
+
+If you have a `default.conf` in your current directory, it will take precedence over the configuration in `~/.tmux/`.
+
 ## Alternatives
 
 There are quite a lot of other approaches to this problem already floating around.

--- a/tmux-up
+++ b/tmux-up
@@ -38,7 +38,11 @@ then
   exit 0
 fi
 
+CONF_DIR=${TMUXUP_CONF_DIR:-$HOME/.tmux}
 CONF=${1:-.tmux.conf}
+
+# try default configuration directory
+[ ! -f "$CONF" ] && CONF="$CONF_DIR/$CONF"
 
 if [ ! -f "$CONF" ]
 then

--- a/tmux-up
+++ b/tmux-up
@@ -56,7 +56,7 @@ NAME=$(basename "$CONF" .conf)
 if [ "$NAME" = 'tmux' ] || [ "$NAME" = '.tmux' ]
 then
   SESSION=$BASE
-elif [ ! -f "${CONF}.conf" ]
+elif [ ! -f "${NAME}.conf" ]
 then
   SESSION=$NAME
 else

--- a/tmux-up
+++ b/tmux-up
@@ -56,6 +56,9 @@ NAME=$(basename "$CONF" .conf)
 if [ "$NAME" = 'tmux' ] || [ "$NAME" = '.tmux' ]
 then
   SESSION=$BASE
+elif [ ! -f "${CONF}.conf" ]
+then
+  SESSION=$NAME
 else
   SESSION=$BASE/$NAME
 fi

--- a/tmux-up
+++ b/tmux-up
@@ -38,7 +38,7 @@ then
   exit 0
 fi
 
-CONF_DIR=${TMUXUP_CONF_DIR:-$HOME/.tmux}
+CONF_DIR=$HOME/.tmux
 CONF=${1:-.tmux.conf}
 
 # try default configuration directory


### PR DESCRIPTION
Tmux-up tries to load a default configuration from ~/.tmux now, if the
specified file doesn't exist in the current directory.
